### PR TITLE
Add `file, scheme, definition` to `useEffect` deps

### DIFF
--- a/src/components/widgets/pseudomutoProtocGenDoc.tsx
+++ b/src/components/widgets/pseudomutoProtocGenDoc.tsx
@@ -181,7 +181,7 @@ export const PseudomutoProtocGenDoc = ({
         setAPIBuild(build)
       }
     })()
-  }, [])
+  }, [file, scheme, definition])
   if (err) {
     return <h1 style={{ color: 'red' }}>Received error: {err}</h1>
   }


### PR DESCRIPTION
Fixes #6

With this PR, `pseudomutoProtocGenDoc` component will be re-rendered when input props change.

You can reproduce this behaviour replacing `example/App.tsx` with the following code:

```tsx
import React, { useState } from 'react'

// import { GRPCGenDocuAPIReference } from 'grpc-docs'
import { GRPCSelfGeneratedAPIReference } from 'grpc-docs'
// import exampleDefinition from './example-definition.json'

const App = () => {
  // return <GRPCGenDocuAPIReference project='LibraryApp' organization='gendocu' />
  // return <GRPCGenDocuAPIReference project='GendocuPublicApis' organization='gendocu' />

  // return  <GRPCSelfGeneratedAPIReference definition={JSON.stringify(exampleDefinition)} />

  const [coin, setCoin] = useState(0)
  const file =
    coin % 2 === 0
      ? '/example-descriptors/all-types.json'
      : '/example-descriptors/library-app.json'
  console.log('App: render with file', file)

  return (
    <div>
      <button onClick={() => setCoin(coin + 1)}>Change</button>
      <GRPCSelfGeneratedAPIReference file={file} />
    </div>
  )
}

export default App
```